### PR TITLE
Add Dashboard component

### DIFF
--- a/components/Charts/LineChart.js
+++ b/components/Charts/LineChart.js
@@ -1,0 +1,74 @@
+import React, { useEffect, useRef } from "react";
+import Chart from "chart.js/auto";
+
+export default function LineChart() {
+  const canvasEl = useRef(null);
+
+  const colors = {
+    purple: {
+      default: "rgba(75,192,192,0.4)",
+      half: "rgba(75,192,192,0.4)",
+      quarter: "rgba(149, 76, 233, 0.25)",
+      zero: "rgba(149, 76, 233, 0)"
+    },
+    indigo: {
+      default: "rgba(80, 102, 120, 1)",
+      quarter: "rgba(80, 102, 120, 0.25)"
+    }
+  };
+
+  useEffect(() => {
+    const ctx = canvasEl.current.getContext("2d");
+    const gradient = ctx.createLinearGradient(0, 16, 0, 600);
+    gradient.addColorStop(0, colors.purple.half);
+    gradient.addColorStop(0.65, colors.purple.quarter);
+    gradient.addColorStop(1, colors.purple.zero);
+
+    const numberOfMissingTools = [3, 4, 5, 3, 6, 5, 5, 3, 2, 3];
+
+    const labels = [
+      "wikibridge",
+      "userwarn-wikidata",
+      "updown-wikidata",
+      "units-converter-wikidata",
+      "taxobox-wikidata",
+      "sort-values",
+      "senseforthisitem",
+      "script-installer",
+      "scholia-link",
+      "requestdeletion"
+    ];
+    const data = {
+      labels: labels,
+      datasets: [
+        {
+          backgroundColor: gradient,
+          label: "My First Dataset",
+          data: numberOfMissingTools,
+          fill: true,
+          borderWidth: 2,
+          borderColor: colors.purple.default,
+          lineTension: 0.2,
+          pointBackgroundColor: colors.purple.default,
+          pointRadius: 3
+        }
+      ]
+    };
+    const config = {
+      type: "line",
+      data: data
+    };
+    const myLineChart = new Chart(ctx, config);
+
+    return function cleanup() {
+      myLineChart.destroy();
+    };
+  });
+
+  return (
+    <div>
+      <span className="title">Number of tools with missing information</span>
+      <canvas id="myChart" ref={canvasEl} height="100" />
+    </div>
+  );
+}

--- a/components/Charts/PieChart.js
+++ b/components/Charts/PieChart.js
@@ -1,0 +1,22 @@
+import React from "react";
+import { Pie } from "react-chartjs-2";
+
+const data = {
+  labels: ["wikibridge", "scholia-link", "updown-wikidata"],
+  datasets: [
+    {
+      data: [100, 70, 30],
+      backgroundColor: ["rgba(75,192,192,0.4", "#36A2EB", "#FF6384"],
+      hoverBackgroundColor: ["rgba(75,192,192,0.4", "#36A2EB", "#FF6384"],
+    },
+  ],
+};
+
+export default function PieChart() {
+  return (
+    <div>
+      <h2 className="title">Percentage of tools with missing information</h2>
+      <Pie data={data} width={400} height={400} />
+    </div>
+  );
+}

--- a/components/Charts/ScatterChart.js
+++ b/components/Charts/ScatterChart.js
@@ -1,0 +1,40 @@
+import React from "react";
+import { Scatter } from "react-chartjs-2";
+
+const data = {
+  labels: ["Scatter"],
+  datasets: [
+    {
+      label: "Number of tools and days tools is edited",
+      fill: false,
+      backgroundColor: "rgba(75,192,192,0.4)",
+      pointBorderColor: "rgba(75,192,192,1)",
+      pointBackgroundColor: "#fff",
+      pointBorderWidth: 5,
+      pointHoverRadius: 10,
+      pointHoverBackgroundColor: "rgba(75,192,192,1)",
+      pointHoverBorderColor: "rgba(220,220,220,1)",
+      pointHoverBorderWidth: 2,
+      pointRadius: 1,
+      pointHitRadius: 10,
+      data: [
+        { x: 65, y: 75 },
+        { x: 59, y: 49 },
+        { x: 80, y: 90 },
+        { x: 81, y: 29 },
+        { x: 56, y: 36 },
+        { x: 55, y: 25 },
+        { x: 40, y: 18 },
+      ],
+    },
+  ],
+};
+
+export default function ScatterChart() {
+  return (
+    <div>
+      <h2 className="title">Number of tools edited using this record management tool</h2>
+      <Scatter data={data} width={400} height={400} />
+    </div>
+  );
+}

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -8,7 +8,7 @@ const Navbar = () => {
         <Image src="/logo.png" alt="site logo" width={80} height={80} />
       </div>
       <Link href="/"><a>Home</a></Link>
-      <Link href="/"><a>Dashboard</a></Link>
+      <Link href="/dashboard/"><a>Dashboard</a></Link>
       <Link href="/leaderboard/"><a>Leaderboard</a></Link>
     </nav>
   );

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "chart.js": "^3.9.1",
     "next": "12.3.1",
     "react": "18.2.0",
+    "react-chartjs-2": "^4.3.1",
     "react-dom": "18.2.0"
   },
   "devDependencies": {

--- a/pages/dashboard/index.js
+++ b/pages/dashboard/index.js
@@ -1,0 +1,24 @@
+import PieChart from '../../components/Charts/PieChart';
+import LineChart from '../../components/Charts/LineChart';
+import styles from '../../styles/Leaderboard.module.css'
+import ScatterChart from '../../components/Charts/ScatterChart';
+
+const Dashboard = () => {
+  return (
+    <div className='p-2'>
+      <div className='m-8'>
+        <LineChart/>
+      </div>
+      <div className="flex flex-row justify-between">
+        <div className="p-2 basis-1/4">
+          <PieChart/>
+        </div>
+        <div className="p-2 basis-1/2">
+          <ScatterChart/>
+        </div>
+      </div>
+    </div>
+  );
+}
+ 
+export default Dashboard;

--- a/pages/leaderboard/index.js
+++ b/pages/leaderboard/index.js
@@ -63,7 +63,7 @@ const Leaderboard = ({ topUsers }) => {
   return (
     <div>
       <h1 className='title'>Toolhub Leaderboard</h1>
-      <h4>These are users that fixed the most snippets through Citation Hunt in the past 30 days. Well done!</h4>
+      <h4>These are users that fixed the most snippets through Toolhub in the past 30 days. Well done!</h4>
       <div className='p-2 m-4 flex flex-row justify-between'>
             <div className='basis-1/4'>
                 <h3 className='font-bold'>User</h3>

--- a/yarn.lock
+++ b/yarn.lock
@@ -421,6 +421,11 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chart.js@^3.9.1:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.9.1.tgz#3abf2c775169c4c71217a107163ac708515924b8"
+  integrity sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w==
+
 chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
@@ -1616,6 +1621,11 @@ quick-lru@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+
+react-chartjs-2@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-chartjs-2/-/react-chartjs-2-4.3.1.tgz#9941e7397fb963f28bb557addb401e9ff96c6681"
+  integrity sha512-5i3mjP6tU7QSn0jvb8I4hudTzHJqS8l00ORJnVwI2sYu0ihpj83Lv2YzfxunfxTZkscKvZu2F2w9LkwNBhj6xA==
 
 react-dom@18.2.0:
   version "18.2.0"


### PR DESCRIPTION
Add Dashboard page component

The dashboard page contains chart and mock figures related to Toolhub data: Number of tools with missing information, percentage of tools with missing information compared with the total number of tools in the records

Task: [T317083](https://phabricator.wikimedia.org/T317083)